### PR TITLE
Improve timing of connection tests

### DIFF
--- a/rclcpp_node/src/cpp_pubsub/src/listener.cpp
+++ b/rclcpp_node/src/cpp_pubsub/src/listener.cpp
@@ -22,7 +22,7 @@ public:
 private:
   void topic_callback(const std_msgs::msg::String::SharedPtr msg) const
   {
-    std::ofstream ofs("cpp_sub.txt");
+    std::ofstream ofs("sub_msg.txt");
     ofs << msg->data.c_str() << std::endl;
     RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "subscribed msg: %s", msg->data.c_str());
     rclcpp::shutdown();

--- a/rclcpp_node/src/cpp_pubsub/src/listener.cpp
+++ b/rclcpp_node/src/cpp_pubsub/src/listener.cpp
@@ -22,7 +22,7 @@ private:
   {
     std::ofstream ofs("cpp_sub.txt");
     ofs << msg->data.c_str() << std::endl;
-    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "subsribed msg: %s", msg->data.c_str());
+    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "subscribed msg: %s", msg->data.c_str());
     rclcpp::shutdown();
   }
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;

--- a/rclcpp_node/src/cpp_pubsub/src/listener.cpp
+++ b/rclcpp_node/src/cpp_pubsub/src/listener.cpp
@@ -15,6 +15,8 @@ public:
   {
     subscription_ = this->create_subscription<std_msgs::msg::String>(
       "testtopic", 10, std::bind(&Listener::topic_callback, this, _1));
+    std::ofstream ofs("sub_ready.txt");
+    ofs << std::endl;
   }
 
 private:

--- a/rclcpp_node/src/cpp_pubsub/src/talker.cpp
+++ b/rclcpp_node/src/cpp_pubsub/src/talker.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[]) {
     publisher->publish(message);
     RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "publishing msg: %s", message.data.c_str());
     std::ofstream ofs("cpp_pub.txt");
-    ofs << message.data;
+    ofs << message.data << std::endl;
     rclcpp::spin_some(node);
     rate.sleep();
   }

--- a/rclcpp_node/src/cpp_pubsub/src/talker.cpp
+++ b/rclcpp_node/src/cpp_pubsub/src/talker.cpp
@@ -36,16 +36,18 @@ int main(int argc, char *argv[]) {
 
   std_msgs::msg::String message;
   message.data = Test_String::get_random_string(10);
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "publishing msg: %s", message.data.c_str());
 
   rclcpp::WallRate rate(1s);
-
-  for (int i = 0; i < 2; i++) {
+  while (true) {
     publisher->publish(message);
-    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "publishing msg: %s", message.data.c_str());
-    std::ofstream ofs("cpp_pub.txt");
+    std::ofstream ofs("pub_msg.txt");
     ofs << message.data << std::endl;
     rclcpp::spin_some(node);
     rate.sleep();
+    std::ifstream ifs("sub_msg.txt");
+    if (ifs.is_open())
+      break;
   }
   rclcpp::shutdown();
   return 0;

--- a/rclcpp_node/src/cpp_pubsub/src/talker.cpp
+++ b/rclcpp_node/src/cpp_pubsub/src/talker.cpp
@@ -21,7 +21,7 @@ public:
     srand (time(NULL));    
     std::string random_string;
     for (int i = 0; i < len; ++i) {
-        random_string += alphanum[rand() % sizeof(alphanum) - 1];
+      random_string += alphanum[rand() % (sizeof(alphanum) - 1)];
     }
     return random_string;
   }

--- a/rclex_node/lib/test/app/simple_pub_sub.ex
+++ b/rclex_node/lib/test/app/simple_pub_sub.ex
@@ -5,17 +5,17 @@ defmodule Test.App.SimplePubSub do
   def pub_main(num_node) do
     # Create data to be published
     data = Test.Helper.String.random_string(10)
-    File.write("ex_pub.txt", data)
+    File.write("ex_pub.txt", data, [:sync])
 
     context = Rclex.rclexinit
     node_list = Rclex.create_nodes(context,'test_pub_node',num_node)
     publisher_list = Rclex.create_publishers(node_list, 'testtopic', :single)
-    {sv, child} = Rclex.Timer.timer_start(publisher_list, 500, &pub_callback/1, 2)
+    {sv, child} = Rclex.Timer.timer_start(publisher_list, 1000, &pub_callback/1, 2)
 
     # In timer_start/2,3, the number of times that the timer process is executed can be set.
     # If it is not set, the timer process loops forever.
 
-    Process.sleep(10000)
+    Process.sleep(3000)
     Rclex.Timer.terminate_timer(sv, child)
     Rclex.publisher_finish(publisher_list, node_list)
     Rclex.node_finish(node_list)
@@ -48,7 +48,7 @@ defmodule Test.App.SimplePubSub do
     subscriber_list = Rclex.create_subscribers(node_list, 'testtopic', :single)
     {sv, child} = Rclex.Subscriber.subscribe_start(subscriber_list, context, &sub_callback/1)
 
-    Process.sleep(10000)
+    Process.sleep(3000)
     Rclex.Subscriber.subscribe_stop(sv, child)
     Rclex.subscriber_finish(subscriber_list, node_list)
     Rclex.node_finish(node_list)
@@ -60,6 +60,6 @@ defmodule Test.App.SimplePubSub do
     # IO.puts("sub time:#{:os.system_time(:microsecond)}")
     received_msg = Rclex.readdata_string(msg)
     IO.puts("[rclex] received msg: #{received_msg}")
-    File.write("ex_sub.txt", received_msg)
+    File.write("ex_sub.txt", received_msg, [:sync])
   end
 end

--- a/rclex_node/lib/test/app/simple_pub_sub.ex
+++ b/rclex_node/lib/test/app/simple_pub_sub.ex
@@ -49,6 +49,9 @@ defmodule Test.App.SimplePubSub do
     {sv, child} = Rclex.Subscriber.subscribe_start(subscriber_list, context, &sub_callback/1)
 
     Process.sleep(3000)
+
+    wait_until_subscription()
+
     Rclex.Subscriber.subscribe_stop(sv, child)
     Rclex.subscriber_finish(subscriber_list, node_list)
     Rclex.node_finish(node_list)
@@ -61,5 +64,14 @@ defmodule Test.App.SimplePubSub do
     received_msg = Rclex.readdata_string(msg)
     IO.puts("[rclex] received msg: #{received_msg}")
     File.write("ex_sub.txt", received_msg, [:sync])
+  end
+
+  defp wait_until_subscription() do
+    if File.exists? ("ex_sub.txt") do
+      IO.puts("[rclex] subscription has completed")
+    else
+      Process.sleep(100)
+      wait_until_subscription()
+    end
   end
 end

--- a/rclex_node/lib/test/app/simple_pub_sub.ex
+++ b/rclex_node/lib/test/app/simple_pub_sub.ex
@@ -49,6 +49,7 @@ defmodule Test.App.SimplePubSub do
     {sv, child} = Rclex.Subscriber.subscribe_start(subscriber_list, context, &sub_callback/1)
 
     Process.sleep(3000)
+    File.write("sub_ready.txt", "", [:sync])
 
     wait_until_subscription()
 

--- a/run-test.sh
+++ b/run-test.sh
@@ -2,6 +2,7 @@
 
 # define testScripts (need to edit when test case was added)
 testScripts=()
+testScripts+=(simple_pubsub/rclcpp_to_rclcpp.sh)
 testScripts+=(simple_pubsub/rclcpp_to_rclex.sh)
 testScripts+=(simple_pubsub/rclex_to_rclcpp.sh)
 testScripts+=(simple_pubsub/rclex_to_rclex.sh)

--- a/simple_pubsub/rclcpp_to_rclcpp.sh
+++ b/simple_pubsub/rclcpp_to_rclcpp.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+cd $1
+
+ros2 run cpp_pubsub listener &
+PID1=$!
+
+echo "TESTINFO: wait for creating subscriber"
+while :
+do
+  if [ -e sub_ready.txt ]; then
+    echo "TESTINFO: subscriber has created"
+    rm -f sub_ready.txt
+    break
+  fi
+  sleep 0.1
+done
+
+ros2 run cpp_pubsub talker &
+PID2=$!
+
+wait $PID1 $PID2
+
+cppPub=`cat cpp_pub.txt | tr -d "\0"`
+echo "TESTINFO: published message  : $cppPub"
+rm -f cpp_pub.txt
+
+cppSub=`cat cpp_sub.txt | tr -d "\0"`
+echo "TESTINFO: subscribed message : $cppSub"
+rm -f ex_sub.txt
+
+test $cppPub = $cppSub
+result=$?
+echo "TESTINFO: result : $result"
+
+if [ $result -ne 0 ]; then
+    echo "TESTERROR: $0 failed."
+    exit 1
+fi

--- a/simple_pubsub/rclcpp_to_rclcpp.sh
+++ b/simple_pubsub/rclcpp_to_rclcpp.sh
@@ -21,13 +21,13 @@ PID2=$!
 
 wait $PID1 $PID2
 
-cppPub=`cat cpp_pub.txt | tr -d "\0"`
+cppPub=`cat pub_msg.txt | tr -d "\0"`
 echo "TESTINFO: published message  : $cppPub"
-rm -f cpp_pub.txt
+rm -f pub_msg.txt
 
-cppSub=`cat cpp_sub.txt | tr -d "\0"`
+cppSub=`cat sub_msg.txt | tr -d "\0"`
 echo "TESTINFO: subscribed message : $cppSub"
-rm -f ex_sub.txt
+rm -f sub_msg.txt
 
 test $cppPub = $cppSub
 result=$?

--- a/simple_pubsub/rclcpp_to_rclex.sh
+++ b/simple_pubsub/rclcpp_to_rclex.sh
@@ -3,12 +3,23 @@
 cd $1
 
 mix run priv/sub_test.exs &
-sleep 1
+PID1=$!
+
+echo "TESTINFO: wait for creating subscriber"
+while :
+do
+  if [ -e sub_ready.txt ]; then
+    echo "TESTINFO: subscriber has created"
+    rm -f sub_ready.txt
+    break
+  fi
+  sleep 0.1
+done
 
 ros2 run cpp_pubsub talker &
-wait
+PID2=$!
 
-sleep 1
+wait $PID1 $PID2
 
 cppPub=`cat cpp_pub.txt | tr -d "\0"`
 echo "TESTINFO: published message  : $cppPub"

--- a/simple_pubsub/rclcpp_to_rclex.sh
+++ b/simple_pubsub/rclcpp_to_rclex.sh
@@ -21,13 +21,13 @@ PID2=$!
 
 wait $PID1 $PID2
 
-cppPub=`cat cpp_pub.txt | tr -d "\0"`
+cppPub=`cat pub_msg.txt | tr -d "\0"`
 echo "TESTINFO: published message  : $cppPub"
-rm -f cpp_pub.txt
+rm -f pub_msg.txt
 
-exSub=`cat ex_sub.txt | tr -d "\0"`
+exSub=`cat sub_msg.txt | tr -d "\0"`
 echo "TESTINFO: subscribed message : $exSub"
-rm -f ex_sub.txt
+rm -f sub_msg.txt
 
 test $cppPub = $exSub
 result=$?

--- a/simple_pubsub/rclex_to_rclcpp.sh
+++ b/simple_pubsub/rclex_to_rclcpp.sh
@@ -21,13 +21,13 @@ PID2=$!
 
 wait $PID1 $PID2
 
-exPub=`cat ex_pub.txt | tr -d "\0"`
+exPub=`cat pub_msg.txt | tr -d "\0"`
 echo "TESTINFO: published message  : $exPub"
-rm -f ex_pub.txt
+rm -f pub_msg.txt
 
-cppSub=`cat cpp_sub.txt | tr -d "\0"`
+cppSub=`cat sub_msg.txt | tr -d "\0"`
 echo "TESTINFO: subscribed message : $cppSub"
-rm -f cpp_sub.txt
+rm -f sub_msg.txt
 
 test $cppSub = $exPub
 result=$?

--- a/simple_pubsub/rclex_to_rclcpp.sh
+++ b/simple_pubsub/rclex_to_rclcpp.sh
@@ -3,12 +3,23 @@
 cd $1
 
 ros2 run cpp_pubsub listener &
-sleep 1
+PID1=$!
+
+echo "TESTINFO: wait for creating subscriber"
+while :
+do
+  if [ -e sub_ready.txt ]; then
+    echo "TESTINFO: subscriber has created"
+    rm -f sub_ready.txt
+    break
+  fi
+  sleep 0.1
+done
 
 mix run priv/pub_test.exs &
-wait
+PID2=$!
 
-sleep 1
+wait $PID1 $PID2
 
 exPub=`cat ex_pub.txt | tr -d "\0"`
 echo "TESTINFO: published message  : $exPub"

--- a/simple_pubsub/rclex_to_rclex.sh
+++ b/simple_pubsub/rclex_to_rclex.sh
@@ -21,13 +21,13 @@ PID2=$!
 
 wait $PID1 $PID2
 
-exPub=`cat ex_pub.txt | tr -d "\0"`
+exPub=`cat pub_msg.txt | tr -d "\0"`
 echo "TESTINFO: published message  : $exPub"
-rm -f ex_pub.txt
+rm -f pub_msg.txt
 
-exSub=`cat ex_sub.txt | tr -d "\0"`
+exSub=`cat sub_msg.txt | tr -d "\0"`
 echo "TESTINFO: subscribed message : $exSub"
-rm -f ex_sub.txt
+rm -f sub_msg.txt
 
 test $exPub = $exSub
 result=$?

--- a/simple_pubsub/rclex_to_rclex.sh
+++ b/simple_pubsub/rclex_to_rclex.sh
@@ -3,12 +3,23 @@
 cd $1
 
 mix run priv/sub_test.exs &
-sleep 1
+PID1=$!
+
+echo "TESTINFO: wait for creating subscriber"
+while :
+do
+  if [ -e sub_ready.txt ]; then
+    echo "TESTINFO: subscriber has created"
+    rm -f sub_ready.txt
+    break
+  fi
+  sleep 0.1
+done
 
 mix run priv/pub_test.exs &
-wait
+PID2=$!
 
-sleep 1
+wait $PID1 $PID2
 
 exPub=`cat ex_pub.txt | tr -d "\0"`
 echo "TESTINFO: published message  : $exPub"


### PR DESCRIPTION
change sync method of pub and sub nodes.

- pub node will start after sub node has created. This sync will be done by creating `sub_ready.txt`.
- pub node will continue until the process of sub node finished. This sync will be done by creating `sub_msg.txt`.

---
NOTE: this may fix https://github.com/rclex/rclex/issues/28