### PR TITLE
replace deprecated syntax `use Mix.Config` to `import Config` (fix #25)

### DIFF
--- a/rclex_node/config/config.exs
+++ b/rclex_node/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :logger,
   backends: [:console],


### PR DESCRIPTION
past warning message:
```
warning: use Mix.Config is deprecated. Use the Config module instead
  config/config.exs:1
```