### PR TITLE
Bump Rclex to v0.10.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2021- [Rclex Dev Team](https://github.com/rclex/)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/rclex_node/config/config.exs
+++ b/rclex_node/config/config.exs
@@ -1,5 +1,7 @@
 import Config
 
+config :rclex, ros2_message_types: ["std_msgs/msg/String"]
+
 config :logger,
   backends: [:console],
   compile_time_purge_matching: [

--- a/rclex_node/config/config.exs
+++ b/rclex_node/config/config.exs
@@ -3,5 +3,5 @@ import Config
 config :logger,
   backends: [:console],
   compile_time_purge_matching: [
-    [level_lower_than: :debug]
+    [level_lower_than: :warning]
   ]

--- a/rclex_node/priv/pub_test.exs
+++ b/rclex_node/priv/pub_test.exs
@@ -1,1 +1,1 @@
-Test.App.SimplePubSub.pub_main(1)
+Test.App.SimplePubSub.pub_main()

--- a/rclex_node/priv/sub_test.exs
+++ b/rclex_node/priv/sub_test.exs
@@ -1,1 +1,1 @@
-Test.App.SimplePubSub.sub_main(1)
+Test.App.SimplePubSub.sub_main()

--- a/run-rebuild.sh
+++ b/run-rebuild.sh
@@ -47,8 +47,8 @@ if [ ${build_rclex} -eq 1 ];
 then
     echo "INFO: building rclcpp node in ${rclexRoot}"
     cd $rclexRoot
-    
     rm -rf _build deps
+
     mix deps.get
     result=$?
     if [ $result -ne 0 ];
@@ -56,7 +56,15 @@ then
         echo "ERROR: \`mix deps.get\` for Rclex failed: $result"
         exit $result
     fi
-    
+
+    mix rclex.gen.msgs
+    result=$?
+    if [ $result -ne 0 ];
+    then
+        echo "ERROR: \`mix rclex.gen.msgs\` for Rclex failed: $result"
+        exit $result
+    fi
+ 
     mix compile
     result=$?
     if [ $result -ne 0 ];


### PR DESCRIPTION
Rclex v0.10.0 のAPI仕様に合うようにテストコードを全面的に修正しました．
当初の実装では，特にN:Nノード通信に対応できるような今後の拡張の余地を残していましたが，いったんそのあたりは削除し，単純に1:1通信のみを対象とするようにしました．今後に追って考えます．

@pojiro よろしければレビュー＆コメントいただけると助かります．
問題なければマージして，これをRclex CI対象としてのrebaseを試みます．