### PR TITLE
repeatedly publish until subscription complete

### DIFF
--- a/rclex_node/lib/test/app/simple_pub_sub.ex
+++ b/rclex_node/lib/test/app/simple_pub_sub.ex
@@ -14,13 +14,21 @@ defmodule Test.App.SimplePubSub do
 
     message = struct(StdMsgs.Msg.String, %{data: "#{data}"})
 
-    IO.puts("[rclex] pub time:#{:os.system_time(:microsecond)}")
     IO.puts("[rclex] publishing msg: #{data}")
     Rclex.publish(message, topic_name, node_name)
 
-    wait_until_subscription()
+    publish_until_subscription(message, topic_name, node_name)
 
     Rclex.stop_node(node_name)
+  end
+
+  defp publish_until_subscription(message, topic_name, node_name) do
+    Rclex.publish(message, topic_name, node_name)
+
+    if !File.exists?("sub_msg.txt") do
+      Process.sleep(1000)
+      publish_until_subscription(message, topic_name, node_name)
+    end
   end
 
   def sub_main() do
@@ -40,7 +48,6 @@ defmodule Test.App.SimplePubSub do
 
   # Describe callback function.
   def sub_callback(msg) do
-    IO.puts("[rclex] sub time:#{:os.system_time(:microsecond)}")
     IO.puts("[rclex] subscribed msg: #{msg.data}")
     File.write("sub_msg.txt", msg.data, [:sync])
   end

--- a/rclex_node/lib/test/app/simple_pub_sub.ex
+++ b/rclex_node/lib/test/app/simple_pub_sub.ex
@@ -10,11 +10,12 @@ defmodule Test.App.SimplePubSub do
 
     # Create data to be published
     data = Test.Helper.String.random_string(10)
-    IO.puts("[rclex] publishing message: #{data}")
     File.write("pub_msg.txt", data, [:sync])
 
     message = struct(StdMsgs.Msg.String, %{data: "#{data}"})
 
+    IO.puts("[rclex] pub time:#{:os.system_time(:microsecond)}")
+    IO.puts("[rclex] publishing msg: #{data}")
     Rclex.publish(message, topic_name, node_name)
 
     wait_until_subscription()
@@ -39,8 +40,8 @@ defmodule Test.App.SimplePubSub do
 
   # Describe callback function.
   def sub_callback(msg) do
-    IO.puts("sub time:#{:os.system_time(:microsecond)}")
-    IO.puts("[rclex] received msg: #{msg.data}")
+    IO.puts("[rclex] sub time:#{:os.system_time(:microsecond)}")
+    IO.puts("[rclex] subscribed msg: #{msg.data}")
     File.write("sub_msg.txt", msg.data, [:sync])
   end
 

--- a/run-rebuild.sh
+++ b/run-rebuild.sh
@@ -45,7 +45,7 @@ fi
 # Rebuild Rclex node
 if [ ${build_rclex} -eq 1 ];
 then
-    echo "INFO: building rclcpp node in ${rclexRoot}"
+    echo "INFO: building rclex node in ${rclexRoot}"
     cd $rclexRoot
     rm -rf _build deps
 


### PR DESCRIPTION
This PR improves the availability of connection tests, mainly for rclex publisher.
In the previous implementation, the pub node published only once, so the test would fail if it took a long time to find a node with which to communicate. As with the original Rclcpp node implementation, I modified it to continue publishing repeatedly until the subscription succeeds. Although multiple subscriptions may occur as a side effect, the communication itself, which is the focus of the test, can be confirmed, and therefore is not considered to be an issues.