### PR TITLE
remove console logger backend from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ cd /path/to/yours/rclex_connection_tests
 $ ./test_in_docker.sh
 ```
 
-You can also specify the target tags of Docker image with any number of arguments (e.g., `latest`, `foxy-ex1.12.3-otp24.1.5`). Please check available Docker tags in [this list](https://github.com/rclex/rclex_docker#available-versions-docker-tags).
+You can also specify the target tags of Docker image with any number of arguments (e.g., `latest`, `humble-ex1.18.4-otp27.3.4.3`). Please check available Docker tags in [this list](https://github.com/rclex/rclex_docker#available-versions-docker-tags).
 
 If you want to operate the test process step by step, the following instruction may be useful.
 

--- a/rclex_node/config/config.exs
+++ b/rclex_node/config/config.exs
@@ -3,7 +3,6 @@ import Config
 config :rclex, ros2_message_types: ["std_msgs/msg/String"]
 
 config :logger,
-  backends: [:console],
   compile_time_purge_matching: [
     [level_lower_than: :warning]
   ]


### PR DESCRIPTION
The module `Logger.Backends.Console` is deprecated in Elixir v1.20 https://logger.hexdocs.pm/1.20.0/Logger.Backends.Console.html

This fix eliminates the folowing message in `./run-test.sh`

```
make: Nothing to be done for 'all'.
warning: the :backends key for the :logger application is deprecated.
Here is how to proceed:

1. If you want to set it to [:console], simply remove the option.

2. If you want to disable logging, remove :backends and instead set:

    config :logger, :default_handler, false

3. If you want to configure any other backend, then it is recommended
   to add `{:logger_backends, "~> 1.0"}` as a dependency and call
   `LoggerBackends.add(CustomBackend)` in your application start callback

  (logger 1.20.0) lib/logger/app.ex:19: Logger.App.start/2
  (kernel 11.0.1) application_master.erl:299: :application_master.start_it_old/4

```